### PR TITLE
SAP-4596 : Make parser return full info string for SVs when GT is None

### DIFF
--- a/cyvcf/parser.pyx
+++ b/cyvcf/parser.pyx
@@ -541,7 +541,7 @@ cdef class Record(object):
         return ';'.join(["%s=%s" % (x, self._stringify(y)) for x, y in self.INFO.items()])
 
     def _format_sample(self, sample):
-        if sample.data.get("GT", None) is None:
+        if sample.data.get("GT", None) is None and not self.is_sv:
             return "./."
         return ':'.join(self._stringify(sample.data[f]) for f in self.FORMAT.split(':'))
 
@@ -1247,7 +1247,7 @@ class Writer(object):
         #return ';'.join("%s=%s" % (x, self._stringify(y)) for x, y in info.items())
 
     def _format_sample(self, fmt, sample):
-        if sample.data.get("GT", None) is None:
+        if sample.data.get("GT", None) is None and not sample.site.is_sv:
             return "./."
         return ':'.join(self._stringify(sample.data[f]) for f in fmt.split(':'))
 


### PR DESCRIPTION
- I have left in the original functionality of returning './.' for null GT because this was in the original cyvcf code so maybe it is important. However, I have made it skip this in the case of SVs with null GT because we want empty GT fields to pass through for these variants and retain all of the original sample information
- See also `https://github.com/Congenica/sapientia-web/pull/5378` for the other code change related to this ticket